### PR TITLE
chore: use bootstrap-switzerland dependency from swiss organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For details about the Swiss Design System, see:
 - [Design System for the Swiss Confederation (Stoybook)](https://swiss.github.io/designsystem/?path=/docs/get-started--docs)
 - [Design System Core Library (Figma)](https://www.figma.com/design/3UYgqxmcJbG0hpWuti3y8U/🇨🇭Design-System-Core-Library)
 
-The application is live at: https://puzzle.github.io/publiccode-editor/
+The application is live at: https://swiss.github.io/publiccode-editor/
 
 Below is the original README for the Italian version.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@uiw/react-md-editor": "^4.0.5",
         "accessible-autocomplete": "^3.0.1",
         "bootstrap": "^5.3.6",
-        "bootstrap-switzerland": "puzzle/bootstrap-switzerland#gh-pages",
+        "bootstrap-switzerland": "swiss/bootstrap-switzerland#gh-pages",
         "copy-to-clipboard": "^3.3.3",
         "countries-list": "^3.0.6",
         "date-fns": "^4.1.0",
@@ -5582,8 +5582,8 @@
       }
     },
     "node_modules/bootstrap-switzerland": {
-      "version": "2.16.0",
-      "resolved": "git+ssh://git@github.com/puzzle/bootstrap-switzerland.git#d638b1c9177b5f66a4e3055c59b2902f835d4494",
+      "version": "2.16.2",
+      "resolved": "git+ssh://git@github.com/swiss/bootstrap-switzerland.git#39349792d85f647c868d255d4f3e4b586f8946a7",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@popperjs/core": "^2.11.6",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:puzzle/publiccode-editor.git"
+    "url": "git@github.com:swiss/publiccode-editor.git"
   },
   "jest": {
     "moduleNameMapper": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@uiw/react-md-editor": "^4.0.5",
     "accessible-autocomplete": "^3.0.1",
     "bootstrap": "^5.3.6",
-    "bootstrap-switzerland": "puzzle/bootstrap-switzerland#gh-pages",
+    "bootstrap-switzerland": "swiss/bootstrap-switzerland#gh-pages",
     "copy-to-clipboard": "^3.3.3",
     "countries-list": "^3.0.6",
     "date-fns": "^4.1.0",

--- a/src/app/contents/constants.ts
+++ b/src/app/contents/constants.ts
@@ -9,7 +9,7 @@ export const {
 } = import.meta.env;
 
 export const documentationUrl = `https://yml.publiccode.tools`;
-export const SAMPLE_YAML_URL = `https://raw.githubusercontent.com/puzzle/publiccode-editor/master/publiccode.yml`;
+export const SAMPLE_YAML_URL = `https://raw.githubusercontent.com/swiss/publiccode-editor/master/publiccode.yml`;
 export const elasticUrl = ELASTIC_URL || "";
 export const AUTOSAVE_TIMEOUT = 15000;
 export const DEFAULT_BRANCH = "master";


### PR DESCRIPTION
Ich habe [bootstrap-switzerland](https://github.com/swiss/bootstrap-switzerland) in die neue `swiss` Organisation gezügelt und musste nun im Editor die entsprechende Dependency anpassen.

Zusätzlich habe ich noch ein paar Urls angepasst, welche noch auf die `puzzle` Organisation zeigten.